### PR TITLE
Make deployment strategy configurable on redis deployment

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -658,11 +658,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: The deployment strategy to use to replace existing pods with
+          new ones.
+        displayName: Strategy
+        path: redis.strategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: In-memory data store resource requirements
         path: redis_resource_requirements
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Redis image
         path: redis_image
         x-descriptors:

--- a/bundle/manifests/pulp.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/pulp.pulpproject.org_pulps.yaml
@@ -456,8 +456,99 @@ spec:
               redis_image:
                 description: The image name for the redis image.
                 type: string
+              redis:
+                description: The pulp redis deployment.
+                properties:
+                  log_level:
+                    default: INFO
+                    description: The log level for the deployment.
+                    enum:
+                    - DEBUG
+                    - INFO
+                    - WARNING
+                    - ERROR
+                    - CRITICAL
+                    type: string
+                  replicas:
+                    default: 2
+                    description: The number of replicas for the deployment.
+                    format: int32
+                    type: integer
+                  resource_requirements:
+                    description: Resource requirements for the pulp redis container
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
+                  strategy:
+                    description: The deployment strategy to use to replace existing
+                      pods with new ones.
+                    properties:
+                      rollingUpdate:
+                        description: 'Rolling update config params. Present only if
+                          DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                          this to follow our convention for oneOf, whatever we decide
+                          it to be.'
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of pods that can be scheduled
+                              above the desired number of pods. Value can be an absolute
+                              number (ex: 5) or a percentage of desired pods (ex:
+                              10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                              number is calculated from percentage by rounding up.
+                              Defaults to 25%. Example: when this is set to 30%, the
+                              new ReplicaSet can be scaled up immediately when the
+                              rolling update starts, such that the total number of
+                              old and new pods do not exceed 130% of desired pods.
+                              Once old pods have been killed, new ReplicaSet can be
+                              scaled up further, ensuring that total number of pods
+                              running at any time during the update is at most 130%
+                              of desired pods.'
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of pods that can be unavailable
+                              during the update. Value can be an absolute number (ex:
+                              5) or a percentage of desired pods (ex: 10%). Absolute
+                              number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0. Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet
+                              can be scaled down to 70% of desired pods immediately
+                              when the rolling update starts. Once new pods are ready,
+                              old ReplicaSet can be scaled down further, followed
+                              by scaling up the new ReplicaSet, ensuring that the
+                              total number of pods available at all times during the
+                              update is at least 70% of desired pods.'
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
               redis_resource_requirements:
-                description: Resource requirements for the Redis container
+                description: (Deprecated, use redis.resource_requirements instead) Resource requirements for the Redis container
                 properties:
                   limits:
                     properties:

--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -320,8 +320,99 @@ spec:
                     description: Defines the node affinity for the deployment
                     type: object
                 type: object
+              redis:
+                description: The pulp redis deployment.
+                properties:
+                  log_level:
+                    default: INFO
+                    description: The log level for the deployment.
+                    enum:
+                    - DEBUG
+                    - INFO
+                    - WARNING
+                    - ERROR
+                    - CRITICAL
+                    type: string
+                  replicas:
+                    default: 2
+                    description: The number of replicas for the deployment.
+                    format: int32
+                    type: integer
+                  resource_requirements:
+                    description: Resource requirements for the pulp redis container
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
+                  strategy:
+                    description: The deployment strategy to use to replace existing
+                      pods with new ones.
+                    properties:
+                      rollingUpdate:
+                        description: 'Rolling update config params. Present only if
+                          DeploymentStrategyType = RollingUpdate. --- TODO: Update
+                          this to follow our convention for oneOf, whatever we decide
+                          it to be.'
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of pods that can be scheduled
+                              above the desired number of pods. Value can be an absolute
+                              number (ex: 5) or a percentage of desired pods (ex:
+                              10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                              number is calculated from percentage by rounding up.
+                              Defaults to 25%. Example: when this is set to 30%, the
+                              new ReplicaSet can be scaled up immediately when the
+                              rolling update starts, such that the total number of
+                              old and new pods do not exceed 130% of desired pods.
+                              Once old pods have been killed, new ReplicaSet can be
+                              scaled up further, ensuring that total number of pods
+                              running at any time during the update is at most 130%
+                              of desired pods.'
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of pods that can be unavailable
+                              during the update. Value can be an absolute number (ex:
+                              5) or a percentage of desired pods (ex: 10%). Absolute
+                              number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0. Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet
+                              can be scaled down to 70% of desired pods immediately
+                              when the rolling update starts. Once new pods are ready,
+                              old ReplicaSet can be scaled down further, followed
+                              by scaling up the new ReplicaSet, ensuring that the
+                              total number of pods available at all times during the
+                              update is at least 70% of desired pods.'
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
               redis_resource_requirements:
-                description: Resource requirements for the Redis container
+                description: (Deprecated, use redis.resource_requirements instead) Resource requirements for the Redis container
                 properties:
                   requests:
                     properties:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -290,11 +290,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: The deployment strategy to use to replace existing pods with
+          new ones.
+        displayName: Strategy
+        path: redis.strategy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:updateStrategy
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: In-memory data store resource requirements
         path: redis_resource_requirements
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Redis image
         path: redis_image
         x-descriptors:

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,10 +1,15 @@
 ---
 _redis_image: redis:latest
 
-redis_resource_requirements:
-  requests:
-    cpu: 200m
-    memory: 512Mi
+redis:
+  strategy: Recreate
+  resource_requirements:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 800m
+      memory: 4Gi
 
 # Here we use  _pulp_pulpproject_org_pulp to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -18,6 +18,10 @@ metadata:
     owner: pulp-dev
 spec:
   replicas: 1
+{% if api.strategy is defined %}
+  strategy:
+    type: {{ redis.strategy }}
+{% endif %}
   selector:
     matchLabels:
       app.kubernetes.io/name: 'redis'
@@ -76,8 +80,8 @@ spec:
                 - -i
                 - -c
                 - redis-cli -h 127.0.0.1 -p 6379
-{% if redis_resource_requirements is defined %}
-          resources: {{ redis_resource_requirements }}
+{% if redis.resource_requirements is defined %}
+          resources: {{ redis.resource_requirements }}
 {% endif %}
 {% if node_selector %}
       nodeSelector:


### PR DESCRIPTION
    Make deployment strategy configurable on redis deployment
      * deprecate redis_resource_requirements in favor of
        redis.resource_requirements


Follow-up for https://github.com/pulp/pulp-operator/pull/644

**Background**

Some users who deploy storage_type set to Azure or AWS (used by api and storage pods) may still not have a RWX storage class on their cluster.  This means the redis PVC would be created as RWO, which causes issues when upgrading if the new redis pod is created on a different underlying node.  

The issue is that the default strategy is RollingUpdate, meaning that the new redis pod is created before the old redis pod is terminated.  This results in a Multi-Attach error if the redis pods are on different nodes, which results in the new redis pod never fully coming online.  

By making the redis.strategy configurable, and setting it's default to "recreate", we can change this behavior so that the old pod is terminated before the new one is created.  